### PR TITLE
Use GCodeWriter to obtain the input g-code

### DIFF
--- a/converter/gcode2ngc.py
+++ b/converter/gcode2ngc.py
@@ -37,20 +37,22 @@ class GCode2Ngc():
         self.hasProgramEnd = False
         self.compile_regex()
 
-    def process_layer(self, layer):
-        newline = self.do_regex_replacements(layer)
-        if (not self.hasProgramEnd) and self.endRegex.match(newline):  # check for end of program
+    def process_layer(self, data):
+        data = self.do_regex_replacements(data)
+        if (not self.hasProgramEnd) and self.endRegex.match(data):  # check for end of program
             self.hasProgramEnd = True
-        return newline
+        return data
 
     def finalize_processing(self, data):
         if not self.hasProgramEnd:
-            data.append(self.endCode + '\n')
+            data += self.endCode + '\n'
+        return data
 
     def process(self, data):
         self.prepare_processing()
 
-        for index, layer in enumerate(data):
-            data[index] = self.process_layer(layer)
+        data = self.process_layer(data)
 
-        self.finalize_processing(data)
+        data = self.finalize_processing(data)
+
+        return data

--- a/converter/ngc2ve.py
+++ b/converter/ngc2ve.py
@@ -332,18 +332,19 @@ class Ngc2Ve():
         self.outputLine("; Input Line Count = " + str(self.line_count))
         self.outputLine("; Output Line Count = " + str(self.output_line_count))
 
-        data.append(''.join(self.outputData))
+        data += ''.join(self.outputData)
         #self.optimizeCross()
+        return data
 
     def process(self, data):
         self.prepare_processing()
 
-        for index, layer in enumerate(data):
-            for line in layer.split('\n'):
-                if line is '':
-                    continue
-                self.process_line(line)
-            data[index] = ''.join(self.outputData)
-            self.outputData = []
+        for line in data.split('\n'):
+            if line is '':
+                continue
+            self.process_line(line)
+        data = ''.join(self.outputData)
+        self.outputData = []
 
-        self.finalize_processing(data)
+        data = self.finalize_processing(data)
+        return data


### PR DESCRIPTION
In the current master version of Cura, this plug-in is broken because we changed the BuildPlateModel class in a recent refactor. I'm tasked to review your plug-in for inclusion in Cura's plug-in browser, but because we broke your API I'm helping you out a bit to fix the stuff that we broke in your plug-in... Sorry about that.

This change causes the plug-in to call Cura's g-code writer plug-in to obtain the original g-code. This will break less often when Ultimaker decides to change the way that it stores g-code internally, because the g-code writer will change accordingly. This should work with Cura 3.0, 3.1, 3.2 and the future 3.3.

This also causes post-processing plug-ins to function again with the NGCWriter.

Most of these changes are required because the GCodeWriter doesn't produce a list of layers but just one string of g-code. I think it simplifies a lot of code slightly.