### PR TITLE
Get Filament diameter from extruder settings

### DIFF
--- a/converter/ngc2ve.py
+++ b/converter/ngc2ve.py
@@ -1,6 +1,7 @@
 import re
 import math
 
+from cura.Settings.ExtruderManager import ExtruderManager
 
 class Ngc2Ve():
     def ___init__(self):
@@ -18,7 +19,8 @@ class Ngc2Ve():
         self.crossList = []
         self.totalCross = []
         self.crossTolerance = 0.05
-        self.filament_d = 1.75
+#        self.filament_d = 1.75
+        self.filament_d = ExtruderManager.getInstance().getActiveExtruderStacks()[0].getProperty("material_diameter", "value")
         self.retracted = True
         self.lastx = 0
         self.lasty = 0


### PR DESCRIPTION
Signed-off-by: Michael Brown <producer@holotronic.dk>

This seems to be the official place to commit this fix for the Cura NGCWriter plugin

The filament diameter was hardcoded to 1.75mm in the plugin, making it not possible to print
with 3mm filament without file editing.
This PR fetches the filament diameter more correctly from the printer extruder settings dialog.